### PR TITLE
Use updated CI configuration (#11)

### DIFF
--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Argument = -sdk 3.1.2.GA
+# Argument = -sdk 6.0.4.GA
 OPTIND=1    # also remember to initialize your flags and other variables
 
 usage()
@@ -11,12 +11,12 @@ Installs various pre-requisites for building a module.
 
 OPTIONS:
    -h      Show this message
-   -s      Version of Titanium SDK to use. If not specified, uses 2.1.3.GA
-   -a      Version of Android SDK to install. If not specified, used 10
+   -s      Version of Titanium SDK to use. If not specified, uses 6.0.4.GA
+   -a      Version of Android SDK to install. If not specified, uses 23
 EOF
 }
 
-export TITANIUM_SDK_VERSION="5.0.2.GA"
+export TITANIUM_SDK_VERSION="6.0.4.GA"
 export TITANIUM_ANDROID_API="23"
 while getopts ":h:s:a:" OPTION
 do
@@ -40,17 +40,17 @@ done
 
 # Need to install jq to process the JSON
 brew update
-brew install jq # process JSON 
+brew install jq # process JSON
 
 sudo npm install -g titanium
 titanium login travisci@appcelerator.com travisci
 titanium sdk install latest --no-progress-bars
 
-# Android SDK seems to require newer version of SDK		
+# Android SDK seems to require newer version of SDK
 echo
-echo "Installing $TITANIUM_SDK_VERSION"		
+echo "Installing $TITANIUM_SDK_VERSION"
 echo
-titanium sdk install -d $TITANIUM_SDK_VERSION --no-progress-bars		
+titanium sdk install -d $TITANIUM_SDK_VERSION --no-progress-bars
 
 export TITANIUM_ROOT=`ti sdk list -o json | jq -r '.defaultInstallLocation'`
 export TITANIUM_SDK=`ti sdk list -o json | jq -r '.installed[.activeSDK]'`
@@ -78,12 +78,12 @@ if [ -d "$MODULE_ROOT/android/" ]; then
   echo
 
   ANDROID_HOME=`ti info -t android -o json | jq -r '.android.sdk.path'`
-  
+
   if [ ! -d "$ANDROID_HOME" ]; then
 
     cd "$TITANIUM_ROOT/sdks/"
-    wget http://dl.google.com/android/android-sdk_r24.0.1-macosx.zip
-    unzip -qq -o android-sdk_r24.0.1-macosx.zip
+    wget https://dl.google.com/android/android-sdk_r24.4.1-macosx.zip
+    unzip -qq -o android-sdk_r24.4.1-macosx.zip
     ANDROID_HOME=${PWD}/android-sdk-macosx
     titanium config android.sdkPath $ANDROID_HOME
 
@@ -91,25 +91,31 @@ if [ -d "$MODULE_ROOT/android/" ]; then
 
   export ANDROID_HOME
   export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-  
+
   echo "Installing and configuring Android SDK + Tools"
 
   # Install required Android components.
-  echo yes | android -s update sdk --no-ui --all --filter \
-    tools,platform-tools,extra-android-support,android-8,android-10,android-$TITANIUM_ANDROID_API,addon-google_apis-google-$TITANIUM_ANDROID_API
-    
-  # NDK r8c
+  # Update tools first so we get latest version of tools and latest repository URL is used to fetch the other packages
+  echo yes | android -s update sdk --no-ui --all --filter tools
+  echo yes | android -s update sdk --no-ui --all --filter platform-tools
+  echo yes | android -s update sdk --no-ui --all --filter build-tools-$TITANIUM_ANDROID_API.0.3
+  echo yes | android -s update sdk --no-ui --all --filter android-21 # Need android 21 because module scripts are hard-coded to this for docgen
+  echo yes | android -s update sdk --no-ui --all --filter android-$TITANIUM_ANDROID_API
+  echo yes | android -s update sdk --no-ui --all --filter addon-google_apis-google-$TITANIUM_ANDROID_API
+  echo yes | android -s update sdk --no-ui --all --filter extra-android-support
+
+  # NDK r11c
   echo
-  echo "Checking existance of $MODULE_ROOT/android-ndk-r8c"
+  echo "Checking existance of $MODULE_ROOT/android-ndk-r11c"
   echo
 
   ANDROID_NDK=`ti info -t android -o json | jq -r '.android.ndk.path'`
 
   if [ ! -d "$ANDROID_NDK" ]; then
     cd "$MODULE_ROOT"
-    wget http://dl.google.com/android/ndk/android-ndk-r8c-darwin-x86.tar.bz2
-    tar xzf android-ndk-r8c-darwin-x86.tar.bz2
-    ANDROID_NDK=${PWD}/android-ndk-r8c
+    wget http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip
+    unzip -q -o android-ndk-r11c-darwin-x86_64.zip
+    ANDROID_NDK=${PWD}/android-ndk-r11c
     titanium config android.ndkPath $ANDROID_NDK
   fi
 
@@ -123,9 +129,9 @@ if [ -d "$MODULE_ROOT/android/" ]; then
     MOUNTDIR=`hdiutil mount javaforosx.dmg | tail -1 | sed -n 's/.*\(\/Volumes\/Java.*\)/\1/p'`
     sudo installer -pkg "${MOUNTDIR}/JavaForOSX.pkg" -target /
   fi
-  
+
   # Write out properties file
- 
+
   echo "titanium.platform=$TITANIUM_SDK/android" > $MODULE_ROOT/build.properties
   echo "android.platform=$ANDROID_HOME/platforms/android-$TITANIUM_ANDROID_API" >> $MODULE_ROOT/build.properties
   echo "google.apis=$ANDROID_HOME/add-ons/addon-google_apis-google-$TITANIUM_ANDROID_API" >> $MODULE_ROOT/build.properties
@@ -135,14 +141,14 @@ fi
 # If iOS module exists, build
 if [ -d "$MODULE_ROOT/ios/" ]; then
   # Write out properties file
- 
+
   echo "TITANIUM_SDK = $TITANIUM_SDK" > $MODULE_ROOT/titanium.xcconfig
   echo "TITANIUM_BASE_SDK = \"\$(TITANIUM_SDK)/iphone/include\"" >> $MODULE_ROOT/titanium.xcconfig
   echo "TITANIUM_BASE_SDK2 = \"\$(TITANIUM_SDK)/iphone/include/TiCore\"" >> $MODULE_ROOT/titanium.xcconfig
   echo "TITANIUM_BASE_SDK3 = \"\$(TITANIUM_SDK)/iphone/include/ASI\"" >> $MODULE_ROOT/titanium.xcconfig
   echo "TITANIUM_BASE_SDK4 = \"\$(TITANIUM_SDK)/iphone/include/APSHTTPClient\"" >> $MODULE_ROOT/titanium.xcconfig
   echo "HEADER_SEARCH_PATHS= \$(TITANIUM_BASE_SDK) \$(TITANIUM_BASE_SDK2) \$(TITANIUM_BASE_SDK3) \$(TITANIUM_BASE_SDK4) \${PROJECT_DIR}/**" >> $MODULE_ROOT/titanium.xcconfig
-  
+
 fi
 
 titanium info

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -9,44 +9,44 @@ if [ -e "$MODULE_ROOT/build.sh" ]; then
 else
 	# If iOS module exists, build
 	if [ -d "$MODULE_ROOT/ios/" ]; then
-	
+
 		echo
 		echo "Building iOS version"
 		echo
-	
+
 		cd $MODULE_ROOT/ios/
 		cp $MODULE_ROOT/titanium.xcconfig titanium.xcconfig
 		cat titanium.xcconfig
 		./build.py
-	
+
 		let STATUS=$?
 		if (( "$RETSTATUS" == "0" )) && (( "$STATUS" != "0" )); then
 		  	let RETSTATUS=$STATUS
-		else 
+		else
 			# Test Module in a Titanium Application
 			echo "Reading module manifest"
 			MODULE_ID=$(sed -n 's/.*moduleid: \([^ ]*\).*/\1/p' manifest)
 			MODULE_VERSION=$(sed -n 's/^version: \([^ ]*\).*/\1/p' manifest)
 			echo "Module Info: " $MODULE_ID '@' $MODULE_VERSION
-	
+
 			#Install module
 			echo "Installing module"
 			ti sdk install $MODULE_ID* -q
-	
+
 			#This already happens in the previous script
 			#echo "Downloading latest SDK"
 			#ti sdk install
 			#ti sdk select latest
-	
+
 			#Create new application
 			echo "Creating new application"
 			ti create -t app -p ios -d "./TestModule" -n "TestModule" --id "com.appc.TestModule" -u "http://appcelerator.com" --force -q
 			cd ./TestModule/TestModule
-	
+
 			#Append module to manifest
 			echo "Add module to application"
 			sed -i "" 's/<modules>/&<module version="'$MODULE_VERSION'">'$MODULE_ID'<\/module>/g' tiapp.xml
-	
+
 			#Configure app.js
 			MODULE_EXAMPLE=$HOME/Library/Application\ Support/Titanium/modules/iphone/$MODULE_ID/$MODULE_VERSION/example/
 			if [ -e "$MODULE_EXAMPLE/app.js" ]; then
@@ -59,52 +59,47 @@ else
 				echo -e "var moduleToTest = require('"$MODULE_ID"');\n$(cat app.js)" > app.js
 				cd ../
 			fi
-	
-			#Append module to app.js
-			cd ./Resources/
-			echo -e "var moduleToTest = require('"$MODULE_ID"');\n$(cat app.js)" > app.js
-			cd ../
-	
+
 			#Build application but do not run simulator
 			echo "Build application"
 			ti build -b -p ios -d "./" —log-level info
-		
+
 			let STATUS=$?
-			
+
 			if (( "$RETSTATUS" == "0" )) && (( "$STATUS" != "0" )); then
 				let RETSTATUS=$STATUS
 			fi
 		fi
 	fi
-	
+
 	# if Android module exists, build
 	if [ -d "$MODULE_ROOT/android/" ]; then
-	
+
 	  echo
 	  echo "Building Android version"
 	  echo
-	
+
 	  cd $MODULE_ROOT/android/
 	  cp $MODULE_ROOT/build.properties build.properties
 	  cat build.properties
-	  
+
 	  # if lib folder doesn't exist, create it
 	  mkdir -p lib
 	  # if build folder doesn't exist, create it
 	  mkdir -p build
 	  # if build/docs folder doesn't exist, create it
 	  mkdir -p build/docs
-	
+
 	  ant clean
 	  ant
-	
+
 	  let STATUS=$?
 	  if (( "$RETSTATUS" == "0" )) && (( "$STATUS" != "0" )); then
 	    let RETSTATUS=$STATUS
 	  fi
-	
+
 	  cd $MODULE_ROOT
-	  
+
 	fi
 fi
 


### PR DESCRIPTION
* update java6 link, edit android update, change versions

* Update module CI scripts
- Use Android NDK r11c
- Use Titanium 5.3.0.GA SDK by default
- modify installation of Android SDK components (use 24.4.1 as base tools)
- Don't inject module require if we already have an example app.js in module
- Install android-21 to make module scripts for docgen happy

* Update install.sh

* Update install.sh

* Update install.sh

* Update script.sh

* Update install.sh

* Update script.sh

* Revert "Use master for CI builds, skip 4.0.0.GA download, use ti build CMD's to build modules"

* Update default SDK versions